### PR TITLE
[COOK-1398] Provider manage.rb ignores username attribute

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -28,7 +28,7 @@ action :remove do
     Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
   else
     search(new_resource.data_bag, "groups:#{new_resource.search_group} AND action:remove") do |rm_user|
-      user rm_user['id'] do
+      user rm_user['username'] ||= rm_user['id'] do
         action :remove
       end
     end
@@ -43,7 +43,8 @@ action :create do
     Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
   else
     search(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove") do |u|
-      security_group << u['id']
+      u['username'] ||= u['id']
+      security_group << u['username']
 
       if node['apache'] and node['apache']['allowed_openids']
         Array(u['openid']).compact.each do |oid|
@@ -56,21 +57,21 @@ action :create do
       if u['home']
         home_dir = u['home']
       else
-        home_dir = "/home/#{u['id']}"
+        home_dir = "/home/#{u['username']}"
       end
 
       # The user block will fail if the group does not yet exist.
       # See the -g option limitations in man 8 useradd for an explanation.
       # This should correct that without breaking functionality.
       if u['gid'] and u['gid'].kind_of?(Numeric)
-        group u['id'] do
+        group u['username'] do
           gid u['gid']
         end
       end
 
       # Create user object.
       # Do NOT try to manage null home directories.
-      user u['id'] do
+      user u['username'] do
         uid u['uid']
         if u['gid']
           gid u['gid']
@@ -87,8 +88,8 @@ action :create do
 
       if home_dir != "/dev/null"
         directory "#{home_dir}/.ssh" do
-          owner u['id']
-          group u['gid'] || u['id']
+          owner u['username']
+          group u['gid'] || u['username']
           mode "0700"
         end
 
@@ -96,8 +97,8 @@ action :create do
           template "#{home_dir}/.ssh/authorized_keys" do
             source "authorized_keys.erb"
             cookbook new_resource.cookbook
-            owner u['id']
-            group u['gid'] || u['id']
+            owner u['username']
+            group u['gid'] || u['username']
             mode "0600"
             variables :ssh_keys => u['ssh_keys']
           end


### PR DESCRIPTION
Reworked manage provider to use 'username' instead of 'id' for the user's name

The original code ignores the use of the 'username' attribute.

This fix allows the use of 'username' which also bypasses some user name limitations inherent to data bags.

For example, I wanted to have a user name with a period in it but the data bag 'id' is limited to alphanumeric, -, _ characters.
