### PR TITLE
[COOK-1583] Ability to set a password

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ Use knife to create a data bag for users.
 
 Create a user in the data_bag/users/ directory.
 
+When using an [Omnibus ruby](http://tickets.opscode.com/browse/CHEF-2848), one can specify an optional password hash.  This
+will be used as the user's password.
+
+The hash can be generated with the following command.
+
+    openssl passwd -1 "plaintextpassword"
+
     knife data bag users bofh
     {
       "id": "bofh",
       "ssh_keys": "ssh-rsa AAAAB3Nz...yhCw== bofh",
+      "password": "$1$d...HgH0",
       "groups": [ "sysadmin", "dba", "devops" ],
       "uid": 2001,
       "shell": "\/bin\/bash",

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -77,6 +77,7 @@ action :create do
         end
         shell u['shell']
         comment u['comment']
+        password u['password'] if u['password']
         if home_dir == "/dev/null"
           supports :manage_home => false
         else


### PR DESCRIPTION
When a 'password' entry exists in the users data bag, chef will set the user's
password.

Depenes on an Omnibus ruby, since it will ship with ruby-shadow. Not attempting
to make this backward compatible with non-omnibus rubies.

The password would not be saved to the data bag in clear text. It would be
hashed, which the user resource already accepts.  Hashing can be achieved with:
    `openssl passwd -1 "plaintextpassword"`
