### PR TITLE
[COOK-2021] Empty default recipe for including users LWRPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ bag in this recipe is `users`. See USAGE.
 Usage
 =====
 
-This cookbook is specific for setting up `sysadmin` group and users for now.
+To include just the LWRPs in your cookbook, use:
+
+    include_recipe "users"
+
+Otherwise, this cookbook is specific for setting up `sysadmin` group and users with the sysadmins recipe for now.
 
     include_recipe "users::sysadmins"
 
@@ -78,7 +82,7 @@ Remove a user, johndoe1.
 * Note only user bags with the "action : remove" and a search-able
   "group" attribute will be purged by the :remove action.
 
-The default recipe makes use of the `users_manage` Lightweight
+The sysadmins recipe makes use of the `users_manage` Lightweight
 Resource Provider (LWRP), and looks like this:
 
     users_manage "sysadmin" do

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          "Apache 2.0"
 description      "Creates users from a databag search"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.2.0"
+recipe           "users", "Empty recipe for including LWRPs"
+recipe           "users::sysadmins", "Create and manage sysadmin group"
 
 %w{ ubuntu debian redhat centos fedora freebsd}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: users
+# Recipe:: default
+#
+# Copyright 2009-2012, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Empty default recipe for including LWRPs.


### PR DESCRIPTION
From http://tickets.opscode.com/browse/COOK-2021:

users_manage LWRP requires you to include_recipe "users::sysadmins", which may not be acceptable if say your system(s) already use GID 2300 for another group or you do not want to create the sysadmins group for whatever reason. The fix is as simple as creating an empty recipes/default.rb so you can include_recipe "users" and use the cookbook LWRPs.
