### PR TITLE
Only notify users_manage when something changes

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+use_inline_resources if defined?(use_inline_resources)
+
 def whyrun_supported?
   true
 end
@@ -43,7 +45,6 @@ action :remove do
         action :remove
       end
     end
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -150,5 +151,4 @@ action :create do
     end
     members security_group
   end
-  new_resource.updated_by_last_action(true)
 end


### PR DESCRIPTION
Previously the users_manage resource notified on every chef run,
regardless of whether something actually changed.  This uses
inline_resources to only notify when one of the inline resources
notifies.

https://tickets.opscode.com/browse/COOK-4139
