### PR TITLE
The directory resource already handles the converge_by functionality

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -111,12 +111,10 @@ action :create do
       if manage_home_files?(home_dir, u['username'])
         Chef::Log.debug("Managing home files for #{u['username']}")
 
-        converge_by("would create #{home_dir}/.ssh") do
-          directory "#{home_dir}/.ssh" do
-            owner u['username']
-            group u['gid'] || u['username']
-            mode "0700"
-          end
+        directory "#{home_dir}/.ssh" do
+          owner u['username']
+          group u['gid'] || u['username']
+          mode "0700"
         end
 
         if u['ssh_keys']


### PR DESCRIPTION
I'm pretty sure this converge_by message is unnecessary.  When I run in --why-run mode, the message comes out even when the .ssh directory exists.
The directory resource has this:
https://github.com/opscode/chef/blob/master/lib/chef/provider/directory.rb#L99
