### PR TITLE
Shouldn't depend on a test cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,3 @@ recipe           "users::sysadmins", "Create and manage sysadmin group"
 %w{ ubuntu debian redhat centos fedora freebsd mac_os_x }.each do |os|
   supports os
 end
-
-depends 'users_test'


### PR DESCRIPTION
Having this dependency may cause an infinite loop in Berkshelf dependency resolution mentioned here https://github.com/berkshelf/solve/issues/27
This is not the main cause and there is still a bug in berkshelf/solve, but I see no reason of keeping it here.
