### PR TITLE
Simplify home directory type detection

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -168,17 +168,13 @@ end
 private
 
 def manage_home_files?(home_dir, user)
-  # Manage files in home dir:
-  # if it's exist and local
-  # or
-  # it's an NFS mount and manage_nfs_home_dirs == true
-  if home_dir == "/dev/null" or not fs_exists?(home_dir)
+  # Don't manage home dir if it's NFS mount
+  # and manage_nfs_home_dirs is disabled
+  if home_dir == "/dev/null"
     false
-  elsif fs_local?(home_dir)
-    true
-  elsif fs_remote?(home_dir) and new_resource.manage_nfs_home_dirs
-    true
+  elsif fs_remote?(home_dir)
+    new_resource.manage_nfs_home_dirs ? true : false
   else
-    false
+    true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 # Point chef-zero at vendored cookbooks
 RSpec.configure do |config|
   config.cookbook_path = 'vendor/cookbooks'
+  config.log_level = :warn
 end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/test/fixtures/cookbooks/users_test/recipes/test_home_dir.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/test_home_dir.rb
@@ -3,3 +3,10 @@ users_manage 'testgroup' do
   action [:remove, :create]
   data_bag 'test_home_dir'
 end
+
+users_manage 'nfsgroup' do
+  group_id 2000
+  action [:remove, :create]
+  data_bag 'test_home_dir'
+  manage_nfs_home_dirs false
+end


### PR DESCRIPTION
- manage home dir if it's type cannot be determined
- manage home dir if it not exists at the beginning of chef run
- add tests with stubbed shellout results

Also this fixes the bug when it was trying to detect FS type at resource compilation stage. Now it assumes remote home dir should be mounted beforehand.
