### PR TITLE
[issues/73] Explicitly remove the authorized_keys file 

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -126,6 +126,10 @@ action :create do
             mode "0600"
             variables :ssh_keys => u['ssh_keys']
           end
+        else
+          if File.exist?("#{home_dir}/.ssh/authorized_keys") do
+            action :delete
+          end
         end
 
         if u['ssh_private_key']


### PR DESCRIPTION
If all ssh keys are removed but not the user itself chef was not zeroing-out the authorized_keys file. This behavior is desirable if you are on a key-only auth system with no SUDO and you remove the user's ssh keys but do not want to wipe out the user entirely. Currently, if you remove all ssh keys from the data bag it never touches the authorized_keys file instead of updating it to represent the changes (IE zeroed-out)
