### PR TITLE
ensure default user group exists

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -108,6 +108,9 @@ action :create do
         action u['action'] if u['action']
       end
 
+      # Ensure default group object is created unless gid is specified
+      group u['username'] unless u['gid']
+
       if manage_home_files?(home_dir, u['username'])
         Chef::Log.debug("Managing home files for #{u['username']}")
 


### PR DESCRIPTION
The create user command will create a group by default. But if a user already exists, but their group does not, the group is never created and this provider will fail.

This change uses the group resource to ensure that the group exists. In normal situations this will be a NOOP but this catches the edge cases. If an explicit gid is specified for the user we can skip this because we assume that group is created/managed elsewhere.

Review: @nathenharvey @jtimberman 