### PR TITLE
remove authorized_keys file if no keys exist, also cleanup authorized_keys2 files

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -117,7 +117,7 @@ action :create do
           mode "0700"
         end
 
-        if u['ssh_keys']
+        if u['ssh_keys'] and u['ssh_keys'].length > 0
           template "#{home_dir}/.ssh/authorized_keys" do
             source "authorized_keys.erb"
             cookbook new_resource.cookbook
@@ -126,6 +126,14 @@ action :create do
             mode "0600"
             variables :ssh_keys => u['ssh_keys']
           end
+        else
+          file "#{home_dir}/.ssh/authorized_keys" do
+            action :delete
+          end
+        end
+        # Ensure there are no authorized_keys2 files laying around, conformity.
+        file "#{home_dir}/.ssh/authorized_keys2" do
+          action :delete
         end
 
         if u['ssh_private_key']


### PR DESCRIPTION
authorized_keys2 was phased out in 2001, but on existing systems may be populated. this makes sure both files are chef managed, and either dont exist or exist in the state we expect. best result security wise for the pubkey files.