### PR TITLE
#111 Resolve Foodcritic warnings

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'users_test', path: 'test/fixtures/cookbooks/users_test'
+group :integration do
+  cookbook 'apt'
+  cookbook 'users_test', path: 'test/fixtures/cookbooks/users_test'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,8 @@ license          'Apache 2.0'
 description      'Creates users from a databag search'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.8.3'
-recipe           'users', 'Empty recipe for including LWRPs'
+
+recipe           'users::default', 'Empty recipe for including LWRPs'
 recipe           'users::sysadmins', 'Create and manage sysadmin group'
 
 %w( ubuntu debian redhat centos fedora freebsd mac_os_x scientific oracle amazon ).each do |os|

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -78,10 +78,9 @@ action :create do
       # The user block will fail if the group does not yet exist.
       # See the -g option limitations in man 8 useradd for an explanation.
       # This should correct that without breaking functionality.
-      if u['gid'] && u['gid'].is_a?(Numeric)
-        group u['username'] do
-          gid u['gid']
-        end
+      group u['username'] do
+        gid u['gid']
+        only_if { u['gid'] && u['gid'].is_a?(Numeric) }
       end
 
       # Create user object.
@@ -110,15 +109,14 @@ action :create do
           mode '0700'
         end
 
-        if u['ssh_keys']
-          template "#{home_dir}/.ssh/authorized_keys" do
-            source 'authorized_keys.erb'
-            cookbook new_resource.cookbook
-            owner u['username']
-            group u['gid'] || u['username']
-            mode '0600'
-            variables ssh_keys: u['ssh_keys']
-          end
+        template "#{home_dir}/.ssh/authorized_keys" do
+          source 'authorized_keys.erb'
+          cookbook new_resource.cookbook
+          owner u['username']
+          group u['gid'] || u['username']
+          mode '0600'
+          variables ssh_keys: u['ssh_keys']
+          only_if { u['ssh_keys'] }
         end
 
         if u['ssh_private_key']


### PR DESCRIPTION
A few minor modifications.

* #111 Resolve Foodcritic warnings
* Explicitly set ::default for default recipe description in cookbook's metadata
* Add 'apt' cookbook to Berksfile integration group to fix failing Test-Kitchen default suit converge. 

Signed-off-by: Robert Northard robertnorthard@googlemail.com