### PR TITLE
Check if shell exists on FreeBSD

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -60,11 +60,18 @@ action :create do
       end
 
       # Set home_basedir based on platform_family
+      home_basedir = '/home'
+
       case node['platform_family']
       when 'mac_os_x'
         home_basedir = '/Users'
-      when 'debian', 'rhel', 'fedora', 'arch', 'suse', 'freebsd', 'openbsd', 'slackware', 'gentoo'
-        home_basedir = '/home'
+      when 'freebsd'
+        # Check if we need to prepend shell with /usr/local/?
+        if not File.exist?(u['shell']) and File.exist?("/usr/local#{u['shell']}")
+          u['shell'] = "/usr/local#{u['shell']}"
+        else
+          u['shell'] = '/bin/sh'
+        end
       end
 
       # Set home to location in data bag,

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -67,7 +67,7 @@ action :create do
         home_basedir = '/Users'
       when 'freebsd'
         # Check if we need to prepend shell with /usr/local/?
-        if not File.exist?(u['shell']) and File.exist?("/usr/local#{u['shell']}")
+        if !File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}")
           u['shell'] = "/usr/local#{u['shell']}"
         else
           u['shell'] = '/bin/sh'


### PR DESCRIPTION
If not, fall back to /bin/sh by default. If it's a manually installed shell, then it lives in /usr/local/bin/{bash,zsh,rbash}.

If the shell is not valid, FreeBSD logins will fail.