### PR TITLE
Speed up testing with kitchen.dokken and adding a users databag

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,91 @@
+---
+driver:
+  name: dokken
+  chef_version: 12.5.1
+  privileged: true # because Docker and SystemD/Upstart
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+verifier:
+  root_path: '/opt/verifier'
+  sudo: false
+#  name: inspec
+
+platforms:
+# someara/chef container does not support centos-5 yet.
+# - name: centos-5
+#   driver:
+#     image: centos:5
+
+- name: centos-6
+  driver:
+    image: centos:6
+
+- name: centos-7
+  driver:
+    image: centos:7
+    pid_one_command: /usr/lib/systemd/systemd
+
+- name: fedora-21
+  driver:
+    image: fedora:21
+    intermediate_instructions:
+    - RUN yum clean all
+    pid_one_command: /usr/lib/systemd/systemd
+
+- name: debian-7
+  driver:
+    image: debian:7
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
+
+# - name: debian-8
+#   driver:
+#     image: debian:8
+#     pid_one_command: /bin/systemd
+#   run_list:
+#   - recipe[apt]
+
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu-upstart:12.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
+
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu-upstart:14.04
+    pid_one_command: /sbin/init
+  run_list:
+  - recipe[apt]
+
+# - name: ubuntu-15.04
+#   driver:
+#     image: ubuntu:15.04
+#     pid_one_command: /bin/systemd
+#   run_list:
+#   - recipe[apt]
+
+suites:
+
+- name: default
+  data_bags_path: "./test/fixtures/data_bags"
+  run_list:
+  - recipe[users_test::test_home_dir]
+#
+# sysadmins
+#
+- name: sysadmins
+  data_bags_path: "./test/fixtures/data_bags"
+  run_list:
+  - recipe[users::sysadmins]
+  attributes:
+    users:
+      data_bag: 'test_sysadmin'

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -89,3 +89,4 @@ suites:
   attributes:
     users:
       data_bag: 'test_sysadmin'
+

--- a/test/fixtures/data_bags/users/sysadmin.json
+++ b/test/fixtures/data_bags/users/sysadmin.json
@@ -1,0 +1,11 @@
+{
+  "id": "sysadmin",
+  "password": "$1$5cE1rI/9$4p0fomh9U4kAI23qUlZVv/",
+  "ssh_keys": [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNrRFi9wrf+M7Q== chefuser@mylaptop.local",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNQCPO0ZZEa1== chefuser@mylaptop.local"
+  ],
+  "groups": [ "sysadmin" ],
+  "shell": "\/bin\/bash",
+  "comment": "Sysadmin"
+}


### PR DESCRIPTION
Added a kitchen.dokken.yml file and discovered that sysadmin recipe failed. I think the sysadmin recipe is a play on 2300, but as is wouldn't work with the existing kitchen.yml files because it's searching for a databag that doesn't exist. The 2 options is to create a users databag or modify the recipe (or remove the recipe from the testing platform.)