### PR TITLE
Resolves Issue 118 fixing provider to work on Mac OS X

### DIFF
--- a/.kitchen.vmware.yml
+++ b/.kitchen.vmware.yml
@@ -1,0 +1,20 @@
+driver:
+  name: vagrant
+  provider: vmware_fusion
+  customize:
+    numvcpus: 2
+    memsize: 2048
+
+provisioner:
+  name: chef_zero
+
+platforms:
+#  - name: macosx-10.8
+#    driver:
+#      box: chef/macosx-10.8 # private
+#  - name: macosx-10.9
+#    driver:
+#      box: chef/macosx-10.9 # private
+  - name: macosx-10.11
+    driver:
+      box: chef/macosx-10.11 # private

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -115,16 +115,16 @@ action :create do
         Chef::Log.debug("Managing home files for #{u['username']}")
 
         directory "#{home_dir}/.ssh" do
-          owner u['username']
-          group u['gid'] || u['username']
+          owner u['uid']
+          group u['gid'] if u['gid']
           mode '0700'
         end
 
         template "#{home_dir}/.ssh/authorized_keys" do
           source 'authorized_keys.erb'
           cookbook new_resource.cookbook
-          owner u['username']
-          group u['gid'] || u['username']
+          owner u['uid']
+          group u['gid'] if u['gid']
           mode '0600'
           variables ssh_keys: u['ssh_keys']
           only_if { u['ssh_keys'] }
@@ -135,8 +135,8 @@ action :create do
           template "#{home_dir}/.ssh/id_#{key_type}" do
             source 'private_key.erb'
             cookbook new_resource.cookbook
-            owner u['id']
-            group u['gid'] || u['id']
+            owner u['uid']
+            group u['gid'] if u['gid']
             mode '0400'
             variables private_key: u['ssh_private_key']
           end
@@ -147,8 +147,8 @@ action :create do
           template "#{home_dir}/.ssh/id_#{key_type}.pub" do
             source 'public_key.pub.erb'
             cookbook new_resource.cookbook
-            owner u['id']
-            group u['gid'] || u['id']
+            owner u['uid']
+            group u['gid'] if u['gid']
             mode '0400'
             variables public_key: u['ssh_public_key']
           end


### PR DESCRIPTION
Added a .kitchen.vmware.yml that only works for Chef employees as
it uses the private images as available on Atlas.

Updated manage.rb to use the uid versus the username provided.
On Mac OS X, using the username for the owner field doesn't work
as expected. Additionally updated the group field to use gid but
only if it exists.