### PR TITLE
merging in modified 375gnu to fix issue 125

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,6 +20,15 @@ module Users
     def fs_remote?(mount)
       fs_type(mount) == 'nfs' ? true : false
     end
+
+    # Validates passed id.
+    #
+    # @return [Numeric, String]
+    # handles checking whether uid was specified as a string
+    
+    def validate_id(id)
+      id.to_i.to_s == id ? id.to_i : id
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -25,7 +25,6 @@ module Users
     #
     # @return [Numeric, String]
     # handles checking whether uid was specified as a string
-    
     def validate_id(id)
       id.to_i.to_s == id ? id.to_i : id
     end

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -78,10 +78,10 @@ action :create do
 
       # Set home to location in data bag,
       # or a reasonable default ($home_basedir/$user).
-      u['home'] ? home_dir = u['home'] : home_dir = "#{home_basedir}/#{u['username']}"
+      home_dir = (u['home'] ? u['home'] : "#{home_basedir}/#{u['username']}")
 
       # check whether home dir is null
-      home_dir == '/dev/null' ? manage_home = false : manage_home = true
+      manage_home = (home_dir == '/dev/null' ? false : true)
 
       # The user block will fail if the group does not yet exist.
       # See the -g option limitations in man 8 useradd for an explanation.

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -97,8 +97,8 @@ action :create do
       # Create user object.
       # Do NOT try to manage null home directories.
       user u['username'] do
-        uid u['uid']
-        gid u['gid'] if u['gid']
+        uid validate_id(u['uid'])
+        gid validate_id(u['gid']) if u['gid']
         shell u['shell']
         comment u['comment']
         password u['password'] if u['password']
@@ -115,16 +115,16 @@ action :create do
         Chef::Log.debug("Managing home files for #{u['username']}")
 
         directory "#{home_dir}/.ssh" do
-          owner u['uid']
-          group u['gid'] if u['gid']
+          owner validate_id(u['uid']) if u['uid'] || u['username']
+          group validate_id(u['gid']) if u['gid']
           mode '0700'
         end
 
         template "#{home_dir}/.ssh/authorized_keys" do
           source 'authorized_keys.erb'
           cookbook new_resource.cookbook
-          owner u['uid']
-          group u['gid'] if u['gid']
+          owner validate_id(u['uid']) if u['uid'] || u['username']
+          group validate_id(u['gid']) if u['gid']
           mode '0600'
           variables ssh_keys: u['ssh_keys']
           only_if { u['ssh_keys'] }
@@ -135,8 +135,8 @@ action :create do
           template "#{home_dir}/.ssh/id_#{key_type}" do
             source 'private_key.erb'
             cookbook new_resource.cookbook
-            owner u['uid']
-            group u['gid'] if u['gid']
+            owner validate_id(u['uid']) if u['uid'] || u['username']
+            group validate_id(u['gid']) if u['gid']
             mode '0400'
             variables private_key: u['ssh_private_key']
           end
@@ -147,8 +147,8 @@ action :create do
           template "#{home_dir}/.ssh/id_#{key_type}.pub" do
             source 'public_key.pub.erb'
             cookbook new_resource.cookbook
-            owner u['uid']
-            group u['gid'] if u['gid']
+            owner validate_id(u['uid']) if u['uid'] || u['username']
+            group validate_id(u['gid']) if u['gid']
             mode '0400'
             variables public_key: u['ssh_public_key']
           end

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -73,7 +73,7 @@ action :create do
         home_basedir = '/Users'
       when 'freebsd'
         # Check if we need to prepend shell with /usr/local/?
-        !File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}") ? u['shell'] = "/usr/local#{u['shell']}" : u['shell'] = '/bin/sh'
+        u['shell'] = (!File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}") ? "/usr/local#{u['shell']}" : '/bin/sh')
       end
 
       # Set home to location in data bag,


### PR DESCRIPTION
This fixes issue 125.

1. if user data bag object has UID specified as a string, will convert to appropriate integer.
  If UID == USERNAME, this will already fail for user creation object.
2. if user data bag object has no uid specified will attempt to set the owner to the username.
  On Mac OS X this will break. So Mac OS X users must specify a UID in the data bag objects.