### PR TITLE
Fix user creation on Mac OS X

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -104,6 +104,8 @@ action :create do
         shell u['shell']
         comment u['comment']
         password u['password'] if u['password']
+        salt u['salt'] if u['salt']
+        iterations u['iterations'] if u['iterations']
         supports manage_home: manage_home
         home home_dir
         action u['action'] if u['action']


### PR DESCRIPTION
Both `salt` and `iterations` attributes are mandatory on Mac OS X, so this adds them if they exists.

Obvious fix.