### PR TITLE
New Feature: Attribute driven users

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,3 +29,12 @@ suites:
     data_bags_path: "./test/fixtures/data_bags"
     run_list:
       - recipe[users::sysadmins]
+
+  - name: attribute-driven-users
+    data_bags_path: "./test/fixtures/data_bags"
+    run_list:
+      - recipe[users::sysadmins]
+    attributes:
+      users:
+        list:
+          - sysadmin_2

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Manages OS users from databags.
 
 This cookbook is concerned with the management of OS users and groups from databags. It also manages the distribution of ssh keys to a user's home directory.
 
+## Attributes
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['users']['list']</tt></td>
+    <td>Array</td>
+    <td> If not empty only users from list will be created </td>
+    <td><tt>[]</tt></td>
+  </tr>
+</table>
+
 ## Requirements
 
 A data bag populated with user objects must exist. The default data bag in this recipe is `users`. See USAGE.
@@ -20,8 +37,8 @@ A data bag populated with user objects must exist. The default data bag in this 
 The following platforms have been tested with Test Kitchen:
 
 - Debian / Ubuntu and derivatives
-- RHEL and derivatives 
-- Fedora 
+- RHEL and derivatives
+- Fedora
 - FreeBSD / OpenBSD
 - Mac OS X
 
@@ -63,6 +80,8 @@ end
 
 **Note**: If you do not specify the data_bag, the default will be to look for a databag called users.
 
+**Note**: If you want to install only part of your users that belong to the group you can specify them in the attribute  `node['users']['list']`
+
 ## Databag Definition
 
 A sample user object in a users databag would look like:
@@ -82,7 +101,7 @@ A sample user object in a users databag would look like:
 }
 ```
 
-### Databag Key Definitions 
+### Databag Key Definitions
 
 * `id`: *String* specifies the username, as well as the data bag object id.
 * `password`: *String* specifies the user's password.
@@ -172,7 +191,7 @@ This `users_manage` resource searches the `users` data bag for the `sysadmin` gr
 
 The recipe, by default, will also create the sysadmin group. The sysadmin group will be created with GID 2300. This may become an attribute at a later date.
 
-## Data bag Overview 
+## Data bag Overview
 
 **Reminder** Data bags generally should not be stored in cookbooks, but in a policy repo within your organization. Data bags are useful across cookbooks, not just for a single cookbook.
 
@@ -287,7 +306,7 @@ $ mkdir data_bags/users
 $EDITOR data_bags/users/bofh.json
 ```
 
-Paste the user's public SSH key into the ssh_keys value. Also make sure the uid is unique, and if you're not using bash, that the shell is installed. 
+Paste the user's public SSH key into the ssh_keys value. Also make sure the uid is unique, and if you're not using bash, that the shell is installed.
 
 The Apache cookbook can set up authentication using OpenIDs, which is set up using the openid key here. See the Chef Software 'apache2' cookbook for more information about this.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This cookbook is concerned with the management of OS users and groups from datab
   <tr>
     <td><tt>['users']['list']</tt></td>
     <td>Array</td>
-    <td> If not empty only users from list will be created </td>
+    <td> If not empty only users from list will be acted on</td>
     <td><tt>[]</tt></td>
   </tr>
 </table>
@@ -80,7 +80,7 @@ end
 
 **Note**: If you do not specify the data_bag, the default will be to look for a databag called users.
 
-**Note**: If you want to install only part of your users that belong to the group you can specify them in the attribute  `node['users']['list']`
+**Note**: If you want to act on only part of your users that belong to the group you can specify them in the attribute  `node['users']['list']`
 
 ## Databag Definition
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+# if list is not empty install only users that are on the list
+default['users']['list']=[]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Creates users from a databag search'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.1.0'
 
 recipe           'users::default', 'Empty recipe for including LWRPs'
 recipe           'users::sysadmins', 'Create and manage sysadmin group'

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -54,101 +54,103 @@ action :create do
     Chef::Log.warn('This recipe uses search. Chef Solo does not support search unless you install the chef-solo-search cookbook.')
   else
     search(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove") do |u|
-      u['username'] ||= u['id']
-      security_group << u['username']
+      if node['users']['list']==[] || node['users']['list'].include?(u['id'])
+        u['username'] ||= u['id']
+        security_group << u['username']
 
-      if node['apache'] && node['apache']['allowed_openids']
-        Array(u['openid']).compact.each do |oid|
-          node.default['apache']['allowed_openids'] << oid unless node['apache']['allowed_openids'].include?(oid)
-        end
-      end
-
-      # Platform specific checks
-      #  Set home_basedir
-      #  Set shell on FreeBSD
-      home_basedir = '/home'
-
-      case node['platform_family']
-      when 'mac_os_x'
-        home_basedir = '/Users'
-      when 'freebsd'
-        # Check if we need to prepend shell with /usr/local/?
-        u['shell'] = (!File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}") ? "/usr/local#{u['shell']}" : '/bin/sh')
-      end
-
-      # Set home to location in data bag,
-      # or a reasonable default ($home_basedir/$user).
-      home_dir = (u['home'] ? u['home'] : "#{home_basedir}/#{u['username']}")
-
-      # check whether home dir is null
-      manage_home = (home_dir == '/dev/null' ? false : true)
-
-      # The user block will fail if the group does not yet exist.
-      # See the -g option limitations in man 8 useradd for an explanation.
-      # This should correct that without breaking functionality.
-      group u['username'] do
-        gid validate_id(u['gid'])
-        only_if { u['gid'] && u['gid'].is_a?(Numeric) }
-      end
-
-      # Create user object.
-      # Do NOT try to manage null home directories.
-      user u['username'] do
-        uid validate_id(u['uid'])
-        gid validate_id(u['gid']) if u['gid']
-        shell u['shell']
-        comment u['comment']
-        password u['password'] if u['password']
-        supports manage_home: manage_home
-        home home_dir
-        action u['action'] if u['action']
-      end
-
-      if manage_home_files?(home_dir, u['username'])
-        Chef::Log.debug("Managing home files for #{u['username']}")
-
-        directory "#{home_dir}/.ssh" do
-          owner u['uid'] ? validate_id(u['uid']) : u['username']
-          group validate_id(u['gid']) if u['gid']
-          mode '0700'
-          only_if { u['ssh_keys'] || u['ssh_private_key'] || u['ssh_public_key'] }
-        end
-
-        template "#{home_dir}/.ssh/authorized_keys" do
-          source 'authorized_keys.erb'
-          cookbook new_resource.cookbook
-          owner u['uid'] ? validate_id(u['uid']) : u['username']
-          group validate_id(u['gid']) if u['gid']
-          mode '0600'
-          variables ssh_keys: u['ssh_keys']
-          only_if { u['ssh_keys'] }
-        end
-
-        if u['ssh_private_key']
-          key_type = u['ssh_private_key'].include?('BEGIN RSA PRIVATE KEY') ? 'rsa' : 'dsa'
-          template "#{home_dir}/.ssh/id_#{key_type}" do
-            source 'private_key.erb'
-            cookbook new_resource.cookbook
-            owner u['uid'] ? validate_id(u['uid']) : u['username']
-            group validate_id(u['gid']) if u['gid']
-            mode '0400'
-            variables private_key: u['ssh_private_key']
+        if node['apache'] && node['apache']['allowed_openids']
+          Array(u['openid']).compact.each do |oid|
+            node.default['apache']['allowed_openids'] << oid unless node['apache']['allowed_openids'].include?(oid)
           end
         end
 
-        if u['ssh_public_key']
-          key_type = u['ssh_public_key'].include?('ssh-rsa') ? 'rsa' : 'dsa'
-          template "#{home_dir}/.ssh/id_#{key_type}.pub" do
-            source 'public_key.pub.erb'
+        # Platform specific checks
+        #  Set home_basedir
+        #  Set shell on FreeBSD
+        home_basedir = '/home'
+
+        case node['platform_family']
+        when 'mac_os_x'
+          home_basedir = '/Users'
+        when 'freebsd'
+          # Check if we need to prepend shell with /usr/local/?
+          u['shell'] = (!File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}") ? "/usr/local#{u['shell']}" : '/bin/sh')
+        end
+
+        # Set home to location in data bag,
+        # or a reasonable default ($home_basedir/$user).
+        home_dir = (u['home'] ? u['home'] : "#{home_basedir}/#{u['username']}")
+
+        # check whether home dir is null
+        manage_home = (home_dir == '/dev/null' ? false : true)
+
+        # The user block will fail if the group does not yet exist.
+        # See the -g option limitations in man 8 useradd for an explanation.
+        # This should correct that without breaking functionality.
+        group u['username'] do
+          gid validate_id(u['gid'])
+          only_if { u['gid'] && u['gid'].is_a?(Numeric) }
+        end
+
+        # Create user object.
+        # Do NOT try to manage null home directories.
+        user u['username'] do
+          uid validate_id(u['uid'])
+          gid validate_id(u['gid']) if u['gid']
+          shell u['shell']
+          comment u['comment']
+          password u['password'] if u['password']
+          supports manage_home: manage_home
+          home home_dir
+          action u['action'] if u['action']
+        end
+
+        if manage_home_files?(home_dir, u['username'])
+          Chef::Log.debug("Managing home files for #{u['username']}")
+
+          directory "#{home_dir}/.ssh" do
+            owner u['uid'] ? validate_id(u['uid']) : u['username']
+            group validate_id(u['gid']) if u['gid']
+            mode '0700'
+            only_if { u['ssh_keys'] || u['ssh_private_key'] || u['ssh_public_key'] }
+          end
+
+          template "#{home_dir}/.ssh/authorized_keys" do
+            source 'authorized_keys.erb'
             cookbook new_resource.cookbook
             owner u['uid'] ? validate_id(u['uid']) : u['username']
             group validate_id(u['gid']) if u['gid']
-            mode '0400'
-            variables public_key: u['ssh_public_key']
+            mode '0600'
+            variables ssh_keys: u['ssh_keys']
+            only_if { u['ssh_keys'] }
           end
+
+          if u['ssh_private_key']
+            key_type = u['ssh_private_key'].include?('BEGIN RSA PRIVATE KEY') ? 'rsa' : 'dsa'
+            template "#{home_dir}/.ssh/id_#{key_type}" do
+              source 'private_key.erb'
+              cookbook new_resource.cookbook
+              owner u['uid'] ? validate_id(u['uid']) : u['username']
+              group validate_id(u['gid']) if u['gid']
+              mode '0400'
+              variables private_key: u['ssh_private_key']
+            end
+          end
+
+          if u['ssh_public_key']
+            key_type = u['ssh_public_key'].include?('ssh-rsa') ? 'rsa' : 'dsa'
+            template "#{home_dir}/.ssh/id_#{key_type}.pub" do
+              source 'public_key.pub.erb'
+              cookbook new_resource.cookbook
+              owner u['uid'] ? validate_id(u['uid']) : u['username']
+              group validate_id(u['gid']) if u['gid']
+              mode '0400'
+              variables public_key: u['ssh_public_key']
+            end
+          end
+        else
+          Chef::Log.debug("Not managing home files for #{u['username']}")
         end
-      else
-        Chef::Log.debug("Not managing home files for #{u['username']}")
       end
     end
   end

--- a/test/fixtures/data_bags/users/sysadmin_2.json
+++ b/test/fixtures/data_bags/users/sysadmin_2.json
@@ -1,0 +1,11 @@
+{
+  "id": "sysadmin_2",
+  "password": "$1$5cE1rI/9$4p0fomh9U4kAI23qUlZVv/",
+  "ssh_keys": [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNrRFi9wrf+M7Q== chefuser@mylaptop.local",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNQCPO0ZZEa1== chefuser@mylaptop.local"
+  ],
+  "groups": [ "sysadmin","testgroup", "nfsgroup" ],
+  "shell": "\/bin\/bash",
+  "comment": "Sysadmin 2 User"
+}

--- a/test/integration/attribute-driven-users/serverspec/default_spec.rb
+++ b/test/integration/attribute-driven-users/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe user('sysadmin_2') do
+  	it { should exist }
+end
+
+describe user('sysadmin') do
+  	it { should_not exist }
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
+  set :backend, :exec
+else
+  set :backend, :cmd
+  set :os, family: 'windows'
+end


### PR DESCRIPTION
### Description

[Describe what this change achieves]
### Issues Resolved

[List any existing issues this PR resolves]
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

This commit gives an ability to choose some of the users from the group that you want to install.
I order to do so one must set node['users']['list'] for example to ['sysadmin_2'].
This will cause that from all other users only sysadmin_2 will be installed( if exist as databag)
