### PR TITLE
Speed up Travis tests runs

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -18,10 +18,9 @@ platforms:
 - name: debian-7
   driver:
     image: debian:7
-    run_command: /sbin/init
+    pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
 
 - name: debian-8
   driver:
@@ -29,7 +28,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
 
 - name: centos-5
   driver:
@@ -37,30 +35,27 @@ platforms:
     platform: rhel
     run_command: /sbin/init
     provision_command:
-      - /usr/bin/yum install -y initscripts net-tools wget
+      - /usr/bin/yum install -y initscripts wget
 
 - name: centos-6
   driver:
     image: centos:6
     intermediate_instructions:
-      - RUN yum -y install tar which initscripts
+      - RUN yum -y install which initscripts
 
 - name: centos-7
   driver:
     image: centos:7
-    intermediate_instructions:
-      - RUN yum clean all
-      - RUN yum -y install net-tools lsof
     pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof
 
 - name: fedora-23
   driver:
     image: fedora:23
-    intermediate_instructions:
-    - RUN yum clean all
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install tar yum
+      - RUN dnf -y install yum
 
 - name: ubuntu-12.04
   driver:
@@ -68,7 +63,6 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
 
 - name: ubuntu-14.04
   driver:
@@ -76,7 +70,6 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
 
 - name: ubuntu-16.04
   driver:
@@ -84,7 +77,13 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https net-tools -y
+
+- name: opensuse-13.2
+  driver:
+    image: opensuse:13.2
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN zypper refresh
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,5 @@
 driver:
   name: vagrant
-  chef_version: 12.5.1
 
 provisioner:
   name: chef_zero
@@ -13,12 +12,15 @@ platforms:
     run_list: apt::default
   - name: debian-8.4
     run_list: apt::default
-  - name: fedora-21
-  - name: fedora-22
+  - name: fedora-23
+    run_list: yum::dnf_yum_compat
   - name: ubuntu-12.04
     run_list: apt::default
   - name: ubuntu-14.04
     run_list: apt::default
+  - name: ubuntu-16.04
+    run_list: apt::default
+  - name: opensuse-13.2
 
 suites:
   - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,13 @@ end
 
 group :kitchen_common do
   gem 'test-kitchen', '~> 1.7'
+  gem 'kitchen-inspec', '~> 0.12'
 end
 
 group :kitchen_vagrant do
   gem 'kitchen-vagrant', '~> 0.20'
+end
+
+group :kitchen_dokken do
+  gem 'kitchen-dokken'
 end

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,5 @@ for details on the process and how to become a maintainer or the project lead.
 
 # Maintainers
 * [Jennifer Davis](https://github.com/sigje)
-* [Sean OMeara](https://github.com/someara)
 * [Tim Smith](https://github.com/tas50)
 * [Thom May](https://github.com/thommay)

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -23,7 +23,6 @@ for details on the process and how to become a maintainer or the project lead.
     
       maintainers = [
         'sigje',
-        'someara',
         'tas50',
         'thommay'
       ]
@@ -32,10 +31,6 @@ for details on the process and how to become a maintainer or the project lead.
   [people.sigje]
     name = "Jennifer Davis"
     github = "sigje"
-
-  [people.someara]
-    name = "Sean OMeara"
-    github = "someara"
 
   [people.tas50]
     name = "Tim Smith"


### PR DESCRIPTION
### Description

Speed up travis test runs by removing some the commands that we run / packages we install prior to the chef install

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

