### PR TITLE
Use explicit ::File to fix FreeBSD support

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -78,7 +78,7 @@ action :create do
         home_basedir = '/Users'
       when 'freebsd'
         # Check if we need to prepend shell with /usr/local/?
-        u['shell'] = (!File.exist?(u['shell']) && File.exist?("/usr/local#{u['shell']}") ? "/usr/local#{u['shell']}" : '/bin/sh')
+        u['shell'] = (!::File.exist?(u['shell']) && ::File.exist?("/usr/local#{u['shell']}") ? "/usr/local#{u['shell']}" : '/bin/sh')
       end
 
       # Set home to location in data bag,


### PR DESCRIPTION
Without this Chef 12.12 and FreeBSD 10.3 gets the following error


    ================================================================================
    Error executing action `create` on resource 'users_manage[sysadmin]'
    ================================================================================

    NoMethodError
    -------------
    undefined method `exist?' for Chef::Provider::File:Class

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/users/providers/manage.rb:81:in `block (2 levels) in class_from_file'
    /var/chef/cache/cookbooks/users/providers/manage.rb:58:in `block in class_from_file'
    /var/chef/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'