### PR TITLE
Fixed new manage_home behaviour that came as a surprise with chef 12.…

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -88,7 +88,7 @@ action :create do
       password u['password'] if u['password']
       salt u['salt'] if u['salt']
       iterations u['iterations'] if u['iterations']
-      supports manage_home: manage_home
+      manage_home manage_home
       home home_dir
       action u['action'] if u['action']
     end


### PR DESCRIPTION
### Description

Fixes the new manage_home behaviour that came with Chef 12.14.60

### Issues Resolved

With latest chef client, the cookbook did not work as it did not create the home for the user, then it failed because it could not create the .ssh subfolder and place the key there

### Check List
- [ x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


…14.60