### PR TITLE
Update manage provider to return true/false in guard block

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -101,7 +101,7 @@ action :create do
         owner u['uid'] ? validate_id(u['uid']) : u['username']
         group validate_id(u['gid']) if u['gid']
         mode '0700'
-        only_if { u['ssh_keys'] || u['ssh_private_key'] || u['ssh_public_key'] }
+        only_if { !!(u['ssh_keys'] || u['ssh_private_key'] || u['ssh_public_key']) }
       end
 
       template "#{home_dir}/.ssh/authorized_keys" do
@@ -111,7 +111,7 @@ action :create do
         group validate_id(u['gid']) if u['gid']
         mode '0600'
         variables ssh_keys: u['ssh_keys']
-        only_if { u['ssh_keys'] }
+        only_if { !!(u['ssh_keys']) }
       end
 
       if u['ssh_private_key']


### PR DESCRIPTION
### Description

Chef > 12.14 added a warn when returning a string in the only_if/not_if guard block
https://github.com/chef/chef/commit/bea83309ccedfe48be5ebac979bb531100f31883

This commit changed these 2 resources which currently warn on latest chef and now return true/false

https://github.com/chef/chef/issues/5574