### PR TITLE
Removal of users from groups via simple data bag entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# users Cookbook
+# users Cookbook - datapipe version
 
 [![Build Status](https://travis-ci.org/chef-cookbooks/users.svg?branch=master)](http://travis-ci.org/chef-cookbooks/users) [![Cookbook Version](https://img.shields.io/cookbook/v/users.svg)](https://supermarket.chef.io/cookbooks/users)
 

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -175,6 +175,7 @@ action :create do
   old_user_groups.each do |g, u|
     # informative, also avoids pesky resource cloning warning
     group "removing users from group #{g}" do
+      group_name g
       excluded_members u
       append true
       action :manage # Do nothing if group doesn't exist

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -35,12 +35,20 @@ end
 action :create do
   users_groups = {}
   users_groups[new_resource.group_name] = []
+  old_user_groups = {}
 
   search(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove") do |u|
     u['username'] ||= u['id']
     u['groups'].each do |g|
       users_groups[g] = [] unless users_groups.key?(g)
       users_groups[g] << u['username']
+    end
+
+    if u['old_groups'] # old_groups is optional
+      u['old_groups'].each do |og|
+        old_user_groups[og] = [] unless old_user_groups.key?(og)
+        old_user_groups[og] << u['username']
+      end
     end
 
     if node['apache'] && node['apache']['allowed_openids']
@@ -162,6 +170,15 @@ action :create do
       gid new_resource.group_id
     end
     members users_groups[new_resource.group_name]
+  end
+
+  old_user_groups.each do |g, u|
+    # informative, also avoids pesky resource cloning warning
+    group "removing users from group #{g}" do
+      excluded_members u
+      append true
+      action :manage # Do nothing if group doesn't exist
+    end
   end
 end
 

--- a/test/fixtures/cookbooks/users_test/recipes/test_home_dir.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/test_home_dir.rb
@@ -10,3 +10,10 @@ users_manage 'nfsgroup' do
   data_bag 'test_home_dir'
   manage_nfs_home_dirs false
 end
+
+users_manage 'oldgroup' do
+  group_id 5000
+  action [:remove, :create]
+  data_bag 'test_home_dir'
+  manage_nfs_home_dirs false
+end

--- a/test/fixtures/data_bags/test_home_dir/test_user.json
+++ b/test/fixtures/data_bags/test_home_dir/test_user.json
@@ -5,7 +5,8 @@
     "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNrRFi9wrf+M7Q== chefuser@mylaptop.local",
     "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNQCPO0ZZEa1== chefuser@mylaptop.local"
   ],
-  "groups": [ "testgroup", "nfsgroup" ],
+  "groups": [ "testgroup", "nfsgroup", "oldgroup" ],
+  "old_groups": [ "oldgroup" ],
   "uid": 9001,
   "shell": "\/bin\/bash",
   "comment": "Test User"


### PR DESCRIPTION
### Description

You can now remove users from groups via the users cookbook. Simply add `"old_groups"` to your user data bag, add the group you want removed, and remove the old group from `"groups"`, and converge. 

Checks: 
- `"old_groups"` is optional in the data bag.
- If a group is mentioned in `"groups"` and `"old_groups"`, the user is still removed after a chef-client run.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
  - No automated tests are passing for 'users' at this point, but I have verified the change in kitchen.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
