### PR TITLE
add support for manage_home = false

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Other potential fields:
 - `action`: _String_ Supported actions are one's supported by the [user](https://docs.chef.io/resource_user.html#actions) resource. If not specified, the default action is `create`.
 - `ssh_private_key`: _String_ manages user's private key generally ~/.ssh/id_*
 - `ssh_public_key`: _String_ manages user's public key generally ~/.ssh/id_*.pub
+- `manage_home`: _Boolean_ can be set to false to disable manage_home when adding user, thus not creating user with a skel.
 
 ## Resources Overview
 

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -49,12 +49,10 @@ action :create do
     # or a reasonable default ($home_basedir/$user).
     home_dir = (u['home'] ? u['home'] : "#{home_basedir}/#{u['username']}")
 
-    # set manage_home according to data bag or check whether home dir is null
-    begin
-      manage_home = u['manage_home']
-    rescue TypeError
-      manage_home = (home_dir == '/dev/null' ? false : true)
-    end
+    # manage_home is true by default but false if home_dir is /dev/null
+    manage_home = (home_dir == '/dev/null' ? false : true)
+    # but we always allow the databag to override it
+    manage_home = u['manage_home'] if u.key?('manage_home')
 
     # The user block will fail if the group does not yet exist.
     # See the -g option limitations in man 8 useradd for an explanation.
@@ -103,7 +101,7 @@ action :create do
         owner u['uid'] ? validate_id(u['uid']) : u['username']
         group gid
         mode '0755'
-        only_if { u['manage_home'] == false }
+        only_if { manage_home == false }
       end
 
       directory "#{home_dir}/.ssh" do

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -94,7 +94,7 @@ action :create do
       # lazy evaluation since user doesn't exist until the execution phase.
       gid = lazy { node['etc']['passwd'][u['username']]['gid'] }
 
-      directory "#{home_dir}" do
+      directory home_dir do
         recursive true
         owner u['uid'] ? validate_id(u['uid']) : u['username']
         group gid

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -50,7 +50,11 @@ action :create do
     home_dir = (u['home'] ? u['home'] : "#{home_basedir}/#{u['username']}")
 
     # set manage_home according to data bag or check whether home dir is null
-    manage_home = u['manage_home'] rescue manage_home = (home_dir == '/dev/null' ? false : true)
+    begin
+      manage_home = u['manage_home']
+    rescue TypeError
+      manage_home = (home_dir == '/dev/null' ? false : true)
+    end
 
     # The user block will fail if the group does not yet exist.
     # See the -g option limitations in man 8 useradd for an explanation.

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -65,6 +65,14 @@ action :create do
       only_if { u['gid'] && u['gid'].is_a?(Numeric) }
     end
 
+    # this fails since the directory resource is evaluated before execution
+    # and that means no user have been created yet and that means there is 
+    # no gid to check up on
+    # ohai 'reload_passwd' do
+    #   action :nothing
+    #   plugin 'etc'
+    # end
+
     # Create user object.
     # Do NOT try to manage null home directories.
     user u['username'] do
@@ -78,18 +86,12 @@ action :create do
       manage_home manage_home
       home home_dir
       action u['action'] if u['action']
+      # read the comment on the ohai block.
+      # notifies :reload, 'ohai[reload_passwd]', :immediately
     end
 
     if manage_home_files?(home_dir, u['username'])
       Chef::Log.debug("Managing home files for #{u['username']}")
-
-      # this fails since the directory resource is evaluated before execution
-      # and that means no user have been created yet and that means there is 
-      # no gid to check up on
-      # ohai 'reload_passwd' do
-      #   action :nothing
-      #   plugin 'etc'
-      # end
 
       directory "#{home_dir}" do
         recursive true
@@ -98,7 +100,6 @@ action :create do
         mode '0755'
         # read the comment on the ohai block.
         # group node['etc']['passwd'][u['username']]['gid']
-        # notifies :reload, 'ohai[reload_passwd]', :before
         only_if { u['manage_home'] == false }
       end
 


### PR DESCRIPTION
add support for manage_home = false.

### Description

Trying to add users without copying /etc/skel.

### Issues Resolved

#403 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
* Testing is not my strong suite, help?
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

