### PR TITLE
Support for custom authorized keys file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['users']['authorized_keys_file'] = 'authorized_keys'

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -91,7 +91,7 @@ action :create do
         only_if { !!(u['ssh_keys'] || u['ssh_private_key'] || u['ssh_public_key']) }
       end
 
-      template "#{home_dir}/.ssh/authorized_keys" do
+      template "#{home_dir}/.ssh/#{node['users']['authorized_keys_file']}" do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
         owner u['uid'] ? validate_id(u['uid']) : u['username']


### PR DESCRIPTION
### Description

Some cloud vendors manage SSH keys in virtual machines (eg. Google
Cloud) using the ~/.ssh/authorized_keys file. Running users cookbook in
these environments breaks that neat feature. Simple workaround is to manage
`~/.ssh/authorized_keys2` file with Chef and leave
`~/.ssh/authorized_keys` for default vendors' orchestration.
Also, it's possible to set custom location of authorized keys file. This feature is documented in SSHD(8):
  > AuthorizedKeysFile specifies the files containing public keys for public key authentication; if this option is not specified, the default is ~/.ssh/authorized_keys and ~/.ssh/authorized_keys2.


### Issues Resolved

https://github.com/chef-cookbooks/users/issues/408

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
