### PR TITLE
allow pulling ssh_keys from a url

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A sample user to remove from a system would like like:
 
 - `id`: _String_ specifies the username, as well as the data bag object id.
 - `password`: _String_ specifies the user's password.
-- `ssh_keys`: _Array_ an array of authorized keys that will be managed by Chef to the user's home directory in .ssh/authorized_keys
+- `ssh_keys`: _Array_ an array of authorized keys that will be managed by Chef to the user's home directory in `$HOME/.ssh/authorized_keys`. A key can include an `https` endpoint that returns a line seperated list of keys such as `https://github.com/$GITHUB_USERNAME.keys` this will retrieve all the keys and add it to the array and can be used with static keys as well as dynamic ones.
 - `groups`: _Array_ an array of groups that the user will be added to
 - `uid`: _Integer_ a unique identifier for the user
 - `shell`: _String_ the user's shell

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,6 +19,17 @@ module Users
       fs_type(mount) == 'nfs' ? true : false
     end
 
+    def keys_from_url(url)
+      host = url.split('/')[0..2].join('/')
+      path = url.split('/')[3..-1].join('/')
+      begin
+        response = Chef::HTTP.new(host).get(path)
+        response.split("\n")
+      rescue Net::HTTPServerException => e
+        p "request: #{host}#{path}, error: #{e}"
+      end
+    end
+
     # Validates passed id.
     #
     # @return [Numeric, String]

--- a/test/fixtures/data_bags/test_home_dir/test_user_keys_url.json
+++ b/test/fixtures/data_bags/test_home_dir/test_user_keys_url.json
@@ -1,0 +1,12 @@
+{
+  "id": "test_user_keys_from_url",
+  "password": "$1$5cE1rI/9$4p0fomh9U4kAI23qUlZVv/",
+  "ssh_keys": [
+    "https://github.com/majormoses.keys",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNQCPO0ZZEa1== chefuser@mylaptop.local"
+  ],
+  "groups": [ "testgroup", "nfsgroup" ],
+  "uid": 9002,
+  "shell": "\/bin\/bash",
+  "comment": "Test User who grabs ssh keys from a url"
+}

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -14,3 +14,23 @@ describe group('nfsgroup') do
   it { should exist }
   its('gid') { should eq 4000 }
 end
+
+describe user('test_user_keys_from_url') do
+  it { should exist }
+  its('uid') { should eq 9002 }
+  its('groups') { should eq %w( test_user_keys_from_url testgroup nfsgroup ) }
+  its('shell') { should eq '/bin/bash' }
+end
+
+# NOTE: this test is super brittle and should probably create a specific github
+# user or mock an HTTP server with the keys
+ssh_keys = [
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC4j6wHVxbs1FQXxV4DaG6RyXMgHfxTSB0tb2uA2Z8kNy9mwZ14zvT9kUCyniXwwTcxbGsxXtjR7qOKrhU0dUnyEu0k2dKIbg8lwkI7aILRnc8wmN7mhoLKifCDlcrNRhhtUjZFVd3Ddmvz8vVOOMElnTQUSy9bw8/WWN2LodFba4RN+9DdIG6nW8bjDbfD5+9jQMHDRbmyBh7FAOe1+T4AowjqRiPuwpxEs7YasQJCHgug0LR1vKF7ufPdUMmv7PxL5kWnZbwis58X/vzfPpOP4VMmhBWLhthrVEz7YFWByguHdnABdX3qM1lEHmb/B+trM7H0qd00Fx5Mg2YxrKOv2pxwX03yDWaJpZSk6WOueKOwPgd5BvOrJ6yZLT7KUJ4NgxnpKWJckoXyy5QfG89G1BWsaEXXQbzxLYLszYzi5YUnRxhZs6cljlGkkoU6qkcUyYcfQ2/7Gp2ElHOnIIQE5m5Tl8yCwGeumt9dwVgxRmVVLidu/NGFhjuQ2Th15V1mVGKPe4xibJATPJILzNPKAekAZqTFRlUm7+rTmg4+a8zWRGpkjq2mPF+pNvlqXFMXBMSleV9CWSpjyZqQI0tNCBUd8kE0ZR3Zn7OxXUvcanh5cgYRHiSeK10TKSd7BkzNUponUZTymZmHyeYLBZ8U1i83VJpQxQGOWbItJdD6MQ==',
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCy3cbPekJYHAIa8J1fOr2iIqpx/7pl4giJYAG7HCfsunRRUq3dY1KhVw1BlmMGIDzNwcuNVIfBS5HS/wREqbHMXxbwAjWrMwUofWd09CTuKJZiyTLUC5pSQWKDXZrefH/Fwd7s+YKk1s78b49zkyDcHSnKxjN+5veinzeU+vaUF9duFAJ9OsL7kTDEzOUU0zJdSdUV0hH1lnljnvk8kXHLFl9sKS3iM2LRqW4B6wOc2RbXUnx+jwNaBsq1zd73F2q3Ta7GXdtW/q4oDYl3s72oW4ySL6TZfpLCiv/7txHicZiY1eqc591CON0k/Rh7eR7XsphwkUstoUPQcBuLqQPA529zBigD7A8PBmeHISxL2qirWjR2+PrEGn1b0yu8IHHz9ZgliX83Q4WpjXvJ3REj2jfM8hiFRV3lA/ovjQrmLLV8WUAZ8updcLE5mbhZzIsC4U/HKIJS02zoggHGHZauClwwcdBtIJnJqtP803yKNPO2sDudTpvEi8GZ8n6jSXo/N8nBVId2LZa5YY/g/v5kH0akn+/E3jXhw4CICNW8yICpeJO8dGYMOp3Bs9/cRK8QYomXqgpoFlvkgzT2h4Ie6lyRgNv5QnUyAnW43O5FdBnPk/XZ3LA462VU3uOfr0AQtEJzPccpFC6OCFYWdGwZQA/r1EZQES0yRfJLpx+uZQ==',
+]
+
+describe file('/home/test_user_keys_from_url/.ssh/authorized_keys') do
+  ssh_keys.each do |key|
+    its('content') { should include(key) }
+  end
+end


### PR DESCRIPTION

#411 

Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

Often people expose ssh public keys via a url such as https://github.com/majormoses.keys which has a line separated list of keys. Basically this allows using static and dynamic ssh keys.


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
