### PR TITLE
Add home directory base for solaris

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,6 +44,8 @@ module Users
     def home_basedir
       if platform_family?('mac_os_x')
         '/Users'
+      elsif platform_family?('solaris2')
+        '/export/home'
       else
         '/home'
       end


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Home directory base path on Solaris platforms is /export/home

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
