### PR TITLE
Add attribute to disable private user group creation for each user

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Other potential fields:
 
 ### users_manage
 
-The `users_manage` resource manages users and groups based off of a data bag search and specified action.
+The `users_manage` resource manages users and groups based off of a data bag search and specified action.  By default, the `users_manage` resource will create a user private group (UPG) for each user.  To disable UPG, set the upg property to false.  Disabling UPG will allow finer grained control over group creation.  Each user's primary group will be set to the first existing group in the user's list of groups as defined in the data bag entry.
 
 #### Examples
 
@@ -150,11 +150,23 @@ users_manage 'nfsgroup' do
 end
 ```
 
+Creates the `usergroup` group, and users defined in the `test_home_dir` databag and sets the primary group for each user to `usergroup` instead of creating separate private groups for each user.
+
+```ruby
+users_manage 'usergroup' do
+  group_id 5000
+  upg false
+  action [:create]
+  data_bag 'test_home_dir'
+end
+```
+
 #### Parameters
 
 - `data_bag` _String_ is the data bag to search
 - `search_group` _String_ groups name to search for, defaults to resource name
 - `group_name` _String_ name of the group to create, defaults to resource name
+- `upg`: _Boolean_ whether to use user private groups (UPG) and create a unique group for each user, default is *True*
 - `group_id` _Integer_ numeric id of the group to create, default is to allow the OS to pick next
 - `cookbook` _String_ name of the cookbook that the authorized_keys template should be found in
 - `manage_nfs_home_dirs` _Boolean_ whether to manage nfs home directories.

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -2,6 +2,13 @@ user 'mwaddams' do
   manage_home true
 end
 
+users_manage 'usergroup' do
+  group_id 5000
+  action [:remove, :create]
+  data_bag 'test_home_dir'
+  upg false
+end
+
 users_manage 'testgroup' do
   group_id 3000
   action [:remove, :create]
@@ -14,3 +21,11 @@ users_manage 'nfsgroup' do
   data_bag 'test_home_dir'
   manage_nfs_home_dirs false
 end
+
+#users_manage 'usergroup' do
+#  group_id 5000
+#  action [:remove, :create]
+#  data_bag 'test_home_dir'
+#  upg false
+#end
+

--- a/test/fixtures/data_bags/test_home_dir/no_privategroup.json
+++ b/test/fixtures/data_bags/test_home_dir/no_privategroup.json
@@ -1,0 +1,8 @@
+{
+  "id": "no_privategroup",
+  "groups": [ "usergroup" ],
+  "ssh_keys": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNrRFi9wrf+M7Q== chefuser@mylaptop.local",
+  "uid": 9003,
+  "comment": "User without a user private group"
+}
+


### PR DESCRIPTION
### Description

This change adds the `upg` attribute to allow User Private Groups to be disabled.  This cookbook has always enforced User Private Groups (UPG), meaning creation of a private group for each user, but some users of this cookbook may prefer more control over group creation and want to disable UPG.  To keep the change non-breaking, the default remains UPG = true.  Setting UPG = false will prevent the user's private group from being created and instead set the user's primary group to the first existing group in the groups entry of the data data bag item.  This allows the user to exist in multiple groups within a data bag without extra converges on every chef-client run.

### Issues Resolved

Resolves #85

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
