### PR TITLE
Allow custom authorized keys file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ users_manage 'testgroup' do
 end
 ```
 
+Or in the case of GCE managing ~/.ssh/authorized_keys:
+
+```ruby
+users_manage 'testgroup' do
+  group_id 3000
+  action [:create]
+  data_bag 'test_home_dir'
+  auth_keys 'authorized_keys2'
+end
+```
+
 **Note**: If you do not specify the data_bag, the default will be to look for a databag called users.
 
 ## Databag Definition

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -22,12 +22,14 @@
 # :group_name is the string name of the group to create, defaults to resource name
 # :group_id is the numeric id of the group to create, default is to allow the OS to pick next
 # :cookbook is the name of the cookbook that the authorized_keys template should be found in
+# :auth_keys is the filename of the public key file, default: ~/.ssh/authorized_keys
 property :data_bag, String, default: 'users'
 property :search_group, String, name_property: true
 property :group_name, String, name_property: true
 property :group_id, Integer
 property :cookbook, String, default: 'users'
 property :manage_nfs_home_dirs, [true, false], default: true
+property :auth_keys, String, default: 'authorized_keys'
 
 action :create do
   users_groups = {}
@@ -99,7 +101,7 @@ action :create do
         end
       end
 
-      template "#{home_dir}/.ssh/authorized_keys" do
+      template "#{home_dir}/.ssh/#{new_resource.auth_keys}" do
         source 'authorized_keys.erb'
         cookbook new_resource.cookbook
         owner u['uid'] ? validate_id(u['uid']) : u['username']

--- a/test/fixtures/cookbooks/users_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/users_test/recipes/default.rb
@@ -14,3 +14,10 @@ users_manage 'nfsgroup' do
   data_bag 'test_home_dir'
   manage_nfs_home_dirs false
 end
+
+users_manage 'authkeys2' do
+  group_id 5000
+  action [:remove, :create]
+  data_bag 'test_home_dir'
+  auth_keys 'authorized_keys2'
+end

--- a/test/fixtures/data_bags/test_home_dir/test_user_authkeys2.json
+++ b/test/fixtures/data_bags/test_home_dir/test_user_authkeys2.json
@@ -1,0 +1,9 @@
+{
+  "id": "test_user_authkeys2",
+  "password": "$1$5cE1rI/9$4p0fomh9U4kAI23qUlZVv/",
+  "ssh_keys": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\nGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\nPbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\nt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\nmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\nNrRFi9wrf+M7Q== chefuser@mylaptop.local",
+  "groups": [ "authkeys2" ],
+  "uid": 10001,
+  "shell": "\/bin\/bash",
+  "comment": "Test authorized_keys2 User"
+}

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,7 +1,24 @@
+if os.suse?
+  test_user_groups = %w( users testgroup nfsgroup )
+  test_user_authkeys2_groups = %w( users authkeys2 )
+  test_user_keys_from_url_groups = %w( users testgroup nfsgroup )
+else
+  test_user_groups = %w( test_user testgroup nfsgroup )
+  test_user_authkeys2_groups = %w( test_user_authkeys2 authkeys2 )
+  test_user_keys_from_url_groups = %w( test_user_keys_from_url testgroup nfsgroup )
+end
+
 describe user('test_user') do
   it { should exist }
   its('uid') { should eq 9001 }
-  its('groups') { should eq %w( test_user testgroup nfsgroup ) }
+  its('groups') { should eq test_user_groups }
+  its('shell') { should eq '/bin/bash' }
+end
+
+describe user('test_user_authkeys2') do
+  it { should exist }
+  its('uid') { should eq 10001 }
+  its('groups') { should eq test_user_authkeys2_groups }
   its('shell') { should eq '/bin/bash' }
 end
 
@@ -15,10 +32,15 @@ describe group('nfsgroup') do
   its('gid') { should eq 4000 }
 end
 
+describe group('authkeys2') do
+  it { should exist }
+  its('gid') { should eq 5000 }
+end
+
 describe user('test_user_keys_from_url') do
   it { should exist }
   its('uid') { should eq 9002 }
-  its('groups') { should eq %w( test_user_keys_from_url testgroup nfsgroup ) }
+  its('groups') { should eq test_user_keys_from_url_groups }
   its('shell') { should eq '/bin/bash' }
 end
 
@@ -33,4 +55,15 @@ describe file('/home/test_user_keys_from_url/.ssh/authorized_keys') do
   ssh_keys.each do |key|
     its('content') { should include(key) }
   end
+end
+
+describe file('/home/test_user_authkeys2/.ssh/authorized_keys') do
+  it { should_not exist }
+end
+
+describe file('/home/test_user_authkeys2/.ssh/authorized_keys2') do
+  it { should exist }
+  it { should be_file }
+  its('mode') { should cmp '0600' }
+  its('owner') { should eq 'test_user_authkeys2' }
 end


### PR DESCRIPTION
### Description

Add a property `auth_keys` to customize the filename for the user's authorized keys.

I feel this is a nice medium change, as modifying data bag content is data modification - and in a multi-os deployment or multi-environment scenario you may not always want to effectively hard-code the path or file name of the authorized keys file. This is more portable and wrapper friendly allowing users to make programmatic choices in providing this value to the custom resource.

I also fixed the opensuse test where the user created doesn't create a same-named group, but instead puts the user in the `users` group.

### Issues Resolved

- #408 
- #409 
- #418 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
