### PR TITLE
accept the ChefDK license in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
+script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 matrix:
   include:
     - script:
-      - chef exec delivery local all
+      - CHEF_LICENSE=accept-no-persist chef exec delivery local all
       env: UNIT_AND_LINT=1


### PR DESCRIPTION
### Description

Since the release of Chef Infra 15, CI/CD pipelines around the world have started failing with a license acceptance prompt.  Accepting this patch would tell ChefDK in the Travis environment that Chef is authorized to use Chef products when testing Chef's own cookbooks.  

### Issues Resolved

Broken pipeline; no issue created.

### Check List

- [x] ~~All tests pass~~.  **Allows tests to run, again**. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- **(n/a)** New functionality includes testing.
- **(n/a)** New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
