### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, and kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Cinc Workstation
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+      - name: Install cookbooks
+        run: chef install Policyfile.rb
       - name: test-kitchen
         uses: actionshub/test-kitchen@3.0.0
         env:
@@ -73,6 +75,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Cinc Workstation
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+      - name: Install cookbooks
+        run: chef install Policyfile.rb
       - name: test-kitchen
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Limitations
+# AGENTS.md
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+name 'users'
+
+run_list 'recipe[test::default]'
+
+cookbook 'users', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'
+
+named_run_list :default, 'recipe[test::default]'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: chef_infra
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -39,10 +40,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -51,5 +48,6 @@ x-verifiers:
 suites:
   - name: default
     data_bags_path: "./test/fixtures/data_bags"
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- add Policyfile.rb for the root users cookbook and local test cookbook
- remove Berksfile/Berksfile.lock usage and stale Berkshelf ignore entries
- switch ChefSpec to chefspec/policyfile and Kitchen to the Policyfile named run list
- replace LIMITATIONS.md with AGENTS.md and update Copilot/CI setup to run chef install Policyfile.rb

## Validation
- gh pr list -R sous-chefs/users --state open --search "Policyfile Berksfile" --json ...: no existing migration PR found
- chef install Policyfile.rb: passed
- cookstyle: passed, 13 files inspected, no offenses
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation: passed, 17 examples, 0 failures
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list: passed, all Linux instances listed
- KITCHEN_LOCAL_YAML=kitchen.exec.yml kitchen list: passed, macos-latest instance listed
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md": passed, 0 errors
- yamllint .: passed
- actionlint: passed
- git diff --check: passed

## Notes
- Plain chef exec rspec is blocked locally by a macOS code-signing error in /Users/damacus/.chef/gem/ruby/3.1.0/gems/json-2.20.0, so RSpec was validated with Chef Workstation's embedded gem path isolated.